### PR TITLE
chore: init.sh SERVER_WAIT_SECONDS 90→5（端侧 TTS 不必等 Mac server）

### DIFF
--- a/device/data_init_native_first.sh
+++ b/device/data_init_native_first.sh
@@ -12,7 +12,9 @@ CONFIG_FILE="${CONFIG_FILE:-/data/native_first.env}"
 SERVER="${SERVER:-http://192.168.8.150:8080}"
 BACKEND="${BACKEND:-deepseek}"
 START_DELAY="${START_DELAY:-20}"
-SERVER_WAIT_SECONDS="${SERVER_WAIT_SECONDS:-90}"
+# 端侧 TTS（TTS_ENGINE=device）不需要 Mac server，开机不必死等它；
+# START_WITHOUT_SERVER=1 会兜底启动，这里调小只为减少开机等待。server 档想等久点可调大。
+SERVER_WAIT_SECONDS="${SERVER_WAIT_SECONDS:-5}"
 START_WITHOUT_SERVER="${START_WITHOUT_SERVER:-1}"
 
 log() {


### PR DESCRIPTION
端侧 TTS（TTS_ENGINE=device）不依赖 Mac server，开机不必死等 90s；START_WITHOUT_SERVER=1 仍兜底启动。已同步改设备 /data/init.sh。

🤖 Generated with [Claude Code](https://claude.com/claude-code)